### PR TITLE
データ未登録時のエラーメッセージ消去

### DIFF
--- a/lib/delivery_state_jp/yuusei.rb
+++ b/lib/delivery_state_jp/yuusei.rb
@@ -16,7 +16,7 @@ module DeliveryStateJp
     end
 
     def self.error_messages
-      %w(お問い合わせ番号の入力桁数に誤りがあります。 お問い合わせ番号が見つかりません。)
+      %w(お問い合わせ番号の入力桁数に誤りがあります。)
     end
   end
 end


### PR DESCRIPTION
郵政はデータ未登録時にお問い合わせ番号が見つかりません。というエラーがでる
西濃はデータ未登録時の返答メッセージがどうなるか判別不能。入力されたお問合せ番号が見当りませんというエラーは入力番号そのもののエラーな模様
検証ができない。西濃のデータ未登録時の返答メッセージが入力されたお問合せ番号が見当りませんというエラーである旨の報告が上がったら、次回修正
https://torisedo.com/43348.html